### PR TITLE
Integrated content loader code with asynchronicity optimizations + made code style-standard compliant

### DIFF
--- a/BITS-App/App.xaml.cs
+++ b/BITS-App/App.xaml.cs
@@ -1,14 +1,12 @@
 ﻿namespace BITS_App;
 
-public partial class App : Application
-{
+public partial class App : Application {
 	// set to client base url
 	public const string BASE_URL = "gwhsnews.org";
 	
 	public static HttpClient client { get; private set; }
 
-	public App()
-	{
+	public App() {
 		InitializeComponent();
 
 		client = new HttpClient();

--- a/BITS-App/AppShell.xaml
+++ b/BITS-App/AppShell.xaml
@@ -8,7 +8,7 @@
     Shell.FlyoutBehavior="Disabled">
 
     <ShellContent
-        ContentTemplate="{DataTemplate views:ArticlePage}"
+        ContentTemplate="{DataTemplate views:PostPage}"
         Route="MainPage" />
 
 </Shell>

--- a/BITS-App/AppShell.xaml.cs
+++ b/BITS-App/AppShell.xaml.cs
@@ -1,9 +1,7 @@
 ﻿namespace BITS_App;
 
-public partial class AppShell : Shell
-{
-	public AppShell()
-	{
+public partial class AppShell : Shell {
+	public AppShell() {
 		InitializeComponent();
 	}
 }

--- a/BITS-App/BITS-App.csproj
+++ b/BITS-App/BITS-App.csproj
@@ -58,7 +58,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <MauiXaml Update="Views\ArticlePage.xaml">
+	  <Compile Update="Views\PostPage.xaml.cs">
+	    <DependentUpon>PostPage.xaml</DependentUpon>
+	  </Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <MauiXaml Update="Views\PostPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>

--- a/BITS-App/MauiProgram.cs
+++ b/BITS-App/MauiProgram.cs
@@ -1,14 +1,11 @@
 ﻿namespace BITS_App;
 
-public static class MauiProgram
-{
-	public static MauiApp CreateMauiApp()
-	{
+public static class MauiProgram {
+	public static MauiApp CreateMauiApp() {
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<App>()
-			.ConfigureFonts(fonts =>
-			{
+			.ConfigureFonts(fonts => {
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
 				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
 				fonts.AddFont("UnifrakturMaguntia.ttf", "UnifrakturMaguntia");

--- a/BITS-App/Models/Post.cs
+++ b/BITS-App/Models/Post.cs
@@ -6,7 +6,7 @@ namespace BITS_App.Models {
     /// <summary>
     /// Model representing a single post entry.
     /// </summary>
-    internal class Article : RestBase {
+    internal class Post : RestBase {
         public override event PropertyChangedEventHandler PropertyChanged;
 
         // FIELDS
@@ -15,10 +15,10 @@ namespace BITS_App.Models {
 
         // CONSTRUCTOR
         /// <summary>
-        /// Initializes a new instance of the <see cref="Article">Article</see> class with the specified ID.
+        /// Initializes a new instance of the <see cref="Post">Post</see> class with the specified ID.
         /// </summary>
         /// <param name="id">ID number of the post</param>
-        public Article(int id) : base($"/wp/v2/posts/{id}") { }
+        public Post(int id) : base($"/wp/v2/posts/{id}") { }
 
         // METHODS
         public override async Task RefreshAsync() {

--- a/BITS-App/Views/ArticlePage.xaml.cs
+++ b/BITS-App/Views/ArticlePage.xaml.cs
@@ -1,81 +1,83 @@
 using HtmlAgilityPack;
+using System.ComponentModel;
 
 namespace BITS_App.Views;
 
-public partial class ArticlePage : ContentPage
-{
-    public ArticlePage()
-    {
+public partial class ArticlePage : ContentPage {
+    public ArticlePage() {
         InitializeComponent();
 
         BindingContext = new Models.Article(7767);
-        
-		    Dispatcher.Dispatch(async () => await ((Models.Article) BindingContext).RefreshAsync());
-        Dispatcher.Dispatch(async () => await LoadContentAsync());
+        ((Models.Article)BindingContext).PropertyChanged += OnPropertyChanged;
+
+        Dispatcher.Dispatch(async () => await ((Models.Article)BindingContext).RefreshAsync());
     }
 
     /// <summary>
     /// Loads content to XAML from HTML Content binding of <see cref="Models.Article">Models.Article</see>
     /// </summary>
-    public async Task LoadContentAsync()
-    {
+    public async Task LoadContentAsync() {
         // gets html in string format
-        string html = ((Models.Article)BindingContext).Content;
+        string html = ((Models.Article)BindingContext).Content ?? "";
 
         // uses agility pack and creates doc with string
         HtmlDocument htmlDoc = new HtmlDocument();
         htmlDoc.LoadHtml(html);
 
+        // spacing between paragraphs, images, etc.
+        contentStackLayout.Spacing = 7;
+
         // gets the nodes
         HtmlNodeCollection parNodes = htmlDoc.DocumentNode.SelectNodes("/");
-        foreach (HtmlNode node in parNodes.Nodes())
-        {
+        foreach (HtmlNode node in parNodes.Nodes()) {
             // if node is named p then it is a paragraph
-            if (node.Name == "p")
-            {
-                Label label = new Label()
-                {
+            if (node.Name == "p") {
+                Label label = new Label() {
                     Text = node.InnerText,
                     FontSize = 14
                     // can format here
                 };
+
                 // adds the paragraph to document
                 contentStackLayout.Add(label);
-            }
-            else if (node.Name == "#text")
-            {
-                // if node is named #text then that is a blank line (a enter)
-                Label label = new Label()
-                {
-                    Text = "",
-                    FontSize = 7
-                    // can format here
-                };
-                contentStackLayout.Add(label);
-            }
-            else if (node.Name == "figure")
-            {
+
+            } else if (node.Name == "#text") {
+                // if node is named #text then that is a blank line (spacing already takes care of that, so we do nothing)
+            } else if (node.Name == "figure") {
                 // this gets the image details of both the image and the caption
                 StackLayout chlidLayout = new StackLayout();
-                Image img = new Image()
-                {
+
+                Image img = new Image() {
                     Source = node.SelectSingleNode("//img").Attributes["src"].Value.ToString()
                     // can format here
                 };
-                Label label = new Label()
-                {
+
+                Label label = new Label() {
                     Padding = 10,
                     Text = node.SelectSingleNode("//figcaption").InnerText,
                     FontSize = 10.5,
                     BackgroundColor = Colors.Transparent
                     // can format here
                 };
+
+                // construct sub-layout with image-caption combination
                 chlidLayout.Add(img);
                 chlidLayout.Add(label);
-                // adds both caption and image at the same time so it is together
+
+                // adds both caption and image at the same time so they are together
                 contentStackLayout.Children.Add(chlidLayout);
             }
         }
     }
 
+    private void OnPropertyChanged(object sender, PropertyChangedEventArgs e) {
+        if (sender == BindingContext) {
+            switch (e.PropertyName) {
+                // if the Content of the model changes, reload it
+                case "Content":
+                    Dispatcher.Dispatch(async () => await LoadContentAsync());
+                    break;
+            }
+        }
+    }
 }

--- a/BITS-App/Views/PostPage.xaml
+++ b/BITS-App/Views/PostPage.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="BITS_App.Views.ArticlePage">
+             x:Class="BITS_App.Views.PostPage">
     <ScrollView>
         <VerticalStackLayout>
             <VerticalStackLayout>

--- a/BITS-App/Views/PostPage.xaml.cs
+++ b/BITS-App/Views/PostPage.xaml.cs
@@ -41,8 +41,6 @@ public partial class PostPage : ContentPage {
                 // adds the paragraph to document
                 contentStackLayout.Add(label);
 
-            } else if (node.Name == "#text") {
-                // if node is named #text then that is a blank line (spacing already takes care of that, so we do nothing)
             } else if (node.Name == "figure") {
                 // this gets the image details of both the image and the caption
                 StackLayout chlidLayout = new StackLayout();

--- a/BITS-App/Views/PostPage.xaml.cs
+++ b/BITS-App/Views/PostPage.xaml.cs
@@ -3,22 +3,22 @@ using System.ComponentModel;
 
 namespace BITS_App.Views;
 
-public partial class ArticlePage : ContentPage {
-    public ArticlePage() {
+public partial class PostPage : ContentPage {
+    public PostPage() {
         InitializeComponent();
 
-        BindingContext = new Models.Article(7767);
-        ((Models.Article)BindingContext).PropertyChanged += OnPropertyChanged;
+        BindingContext = new Models.Post(7767);
+        ((Models.Post)BindingContext).PropertyChanged += OnPropertyChanged;
 
-        Dispatcher.Dispatch(async () => await ((Models.Article)BindingContext).RefreshAsync());
+        Dispatcher.Dispatch(async () => await ((Models.Post)BindingContext).RefreshAsync());
     }
 
     /// <summary>
-    /// Loads content to XAML from HTML Content binding of <see cref="Models.Article">Models.Article</see>
+    /// Loads content to XAML from HTML Content binding of <see cref="Models.Post">Models.Post</see>
     /// </summary>
     public async Task LoadContentAsync() {
         // gets html in string format
-        string html = ((Models.Article)BindingContext).Content ?? "";
+        string html = ((Models.Post)BindingContext).Content ?? "";
 
         // uses agility pack and creates doc with string
         HtmlDocument htmlDoc = new HtmlDocument();


### PR DESCRIPTION
This is a pretty simple branch, all things considered. I just made some quick changes and integrations for the content loader and semantics:

- Content loader is now properly integrated into the new PropertyChanged event technique I implemented recently.
- I made a minor optimization to the content loader - there's no need to toss in blank lines when we can just use Spacing.
- All references to Article and the like have been changed to Post. This is just because the server calls them Posts so I figured we should maintain semantic parity.