### PR TITLE
Dev staff page

### DIFF
--- a/BITS-App/AppTabbedPage.xaml
+++ b/BITS-App/AppTabbedPage.xaml
@@ -21,7 +21,7 @@
     
     <NavigationPage Title="Staff">
         <x:Arguments>
-            <pages:StaffProfilePage/>
+            <pages:StaffPage/>
         </x:Arguments>
     </NavigationPage>
 

--- a/BITS-App/BITS-App.csproj
+++ b/BITS-App/BITS-App.csproj
@@ -70,13 +70,15 @@
 	  <MauiXaml Update="Pages\PostPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Pages\StaffPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Pages\StaffProfilePage.xaml">
       <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Folder Include="ViewModels\" />
 	  <Folder Include="Views\" />
 	</ItemGroup>
 </Project>

--- a/BITS-App/Json/StaffProfile.cs
+++ b/BITS-App/Json/StaffProfile.cs
@@ -50,7 +50,8 @@ public class StaffProfile {
 		}
 	}
     public string excerpt { get; set; }
-    public Uri profileImageUrl { get; set; }
+    // This field causes errors when a profile doesn't have an image set. I assume there's a way to deal with this with the the json library we're using, but time constraints prevent me from doing so. I leave this to posterity to deal with - Ethan
+	//public Uri profileImageUrl { get; set; }
     public Links _links { get; set; }
     public class Links {
         public List<Hyperlink> self { get; set; }

--- a/BITS-App/Models/StaffProfile.cs
+++ b/BITS-App/Models/StaffProfile.cs
@@ -11,11 +11,27 @@ public class StaffProfile : RestBase {
     public override event PropertyChangedEventHandler PropertyChanged;
 
     #region FIELDS
-    protected Json.StaffProfile json;
-	protected Media featuredMedia;
+    private Json.StaffProfile _json;
+    public Json.StaffProfile json
+    {
+        get
+        {
+            return _json;
+
+        }
+        set
+        {
+            _json = value;
+            endpoint = value?.id == null ? "" : $"/wp/v2/staff_profile/{value.id}";
+        }
+    }
+    protected Media featuredMedia;
     #endregion
 
-    #region CONSTRUCTOR
+    #region CONSTRUCTORS
+
+    public StaffProfile() { }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="StaffProfile">StaffProfile</see> class with the specified ID.
     /// </summary>
@@ -33,7 +49,7 @@ public class StaffProfile : RestBase {
 			HttpResponseMessage response = await App.client.GetAsync(uri);
 			if (response.IsSuccessStatusCode) {
 				string content = await response.Content.ReadAsStringAsync();
-				json = JsonConvert.DeserializeObject<Json.StaffProfile>(content);
+				_json = JsonConvert.DeserializeObject<Json.StaffProfile>(content);
 			}
 		} catch (Exception ex) {
 			Debug.WriteLine(@"\tERROR {0}", ex.Message);
@@ -45,7 +61,7 @@ public class StaffProfile : RestBase {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Bio"));
 
         // generates a Media model for the Featured Media and registers to updates like a binding would - this is supposed to be directly bound to the view, but MAUI doesn't support that as of this writing, so we use a workaround
-        featuredMedia = new Media(json.featured_media);
+        featuredMedia = new Media(_json.featured_media);
         featuredMedia.PropertyChanged += OnPropertyChanged;
 
         // refreshes the Media model
@@ -64,9 +80,9 @@ public class StaffProfile : RestBase {
 
     #region BINDINGS
 #nullable enable
-    public string? Name => json?.title?.rendered;
-    public string? Excerpt => json?.excerpt;
-    public string? Bio => json?.content?.rendered;
+    public string? Name => _json?.title?.rendered;
+    public string? Excerpt => _json?.excerpt;
+    public string? Bio => _json?.content?.rendered;
     public string? FeaturedMedia => featuredMedia?.Link;
 #nullable disable
     #endregion

--- a/BITS-App/Models/StaffProfile.cs
+++ b/BITS-App/Models/StaffProfile.cs
@@ -12,15 +12,11 @@ public class StaffProfile : RestBase {
 
     #region FIELDS
     private Json.StaffProfile _json;
-    public Json.StaffProfile json
-    {
-        get
-        {
+    public Json.StaffProfile json {
+        get {
             return _json;
-
         }
-        set
-        {
+        set {
             _json = value;
             endpoint = value?.id == null ? "" : $"/wp/v2/staff_profile/{value.id}";
         }

--- a/BITS-App/Pages/StaffPage.xaml
+++ b/BITS-App/Pages/StaffPage.xaml
@@ -3,10 +3,54 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="BITS_App.Pages.StaffPage"
              Title="StaffPage">
-    <VerticalStackLayout>
-        <Label 
-            Text="Welcome to .NET MAUI!"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center" />
-    </VerticalStackLayout>
+    <ScrollView>
+        <CollectionView ItemsSource="{Binding StaffProfiles}"
+                        Margin="20">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid HeightRequest="100"
+                          BackgroundColor="LightGrey">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnTapGestureRecognizerTapped" />
+                        </Grid.GestureRecognizers>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="100"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Image Grid.Column="0"
+                               Source="{Binding Path=FeaturedMedia, FallbackValue='fallback_image.png', TargetNullValue='fallback_image.png'}"
+                               WidthRequest="100"
+                               HeightRequest="100"
+                               Aspect="AspectFill"/>
+
+                        <VerticalStackLayout Grid.Column="1"
+                                             HeightRequest="100"
+                                             HorizontalOptions="FillAndExpand"
+                                             Spacing="5"
+                                             Padding="10">
+                            <Label Text="{Binding Path=Name, FallbackValue='Name', TargetNullValue='null'}"
+                                   FontAttributes="Bold"
+                                   FontSize="15"
+                                   HorizontalTextAlignment="Start"
+                                   LineBreakMode="TailTruncation"
+                                   VerticalTextAlignment="Start"
+                                   TextColor="White"/>
+
+                            <Label Text="{Binding Excerpt}"
+                                   FontAttributes="Bold"
+                                   FontSize="8"
+                                   HeightRequest="40"
+                                   MaxLines="3"
+                                   HorizontalTextAlignment="Start"
+                                   VerticalTextAlignment="Start"
+                                   TextColor="White"/>
+
+                        </VerticalStackLayout>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </ScrollView>
 </ContentPage>

--- a/BITS-App/Pages/StaffPage.xaml
+++ b/BITS-App/Pages/StaffPage.xaml
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="utf-8" ?>
+\<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="BITS_App.Pages.StaffPage"
              Title="StaffPage">
     <ScrollView>
         <CollectionView ItemsSource="{Binding StaffProfiles}"
+                        ItemsLayout="VerticalGrid, 2"
                         Margin="20">
             <CollectionView.ItemTemplate>
                 <DataTemplate>

--- a/BITS-App/Pages/StaffPage.xaml
+++ b/BITS-App/Pages/StaffPage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="BITS_App.Pages.StaffPage"
+             Title="StaffPage">
+    <VerticalStackLayout>
+        <Label 
+            Text="Welcome to .NET MAUI!"
+            VerticalOptions="Center" 
+            HorizontalOptions="Center" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/BITS-App/Pages/StaffPage.xaml.cs
+++ b/BITS-App/Pages/StaffPage.xaml.cs
@@ -1,5 +1,4 @@
 using BITS_App.ViewModels;
-using System.Runtime.CompilerServices;
 
 namespace BITS_App.Pages;
 

--- a/BITS-App/Pages/StaffPage.xaml.cs
+++ b/BITS-App/Pages/StaffPage.xaml.cs
@@ -3,20 +3,16 @@ using System.Runtime.CompilerServices;
 
 namespace BITS_App.Pages;
 
-public partial class StaffPage : ContentPage
-{
-	public StaffPage()
-	{
+public partial class StaffPage : ContentPage {
+	public StaffPage() {
 		InitializeComponent();
         BindingContext = new StaffViewModel();
         Dispatcher.Dispatch(async () => await ((StaffViewModel)BindingContext).RefreshAsync());
     }
 
-    void OnTapGestureRecognizerTapped(object sender, TappedEventArgs e)
-    {
+    void OnTapGestureRecognizerTapped(object sender, TappedEventArgs e) {
         Dispatcher.Dispatch(async () => {
-            await Navigation.PushAsync(new StaffProfilePage()
-            {
+            await Navigation.PushAsync(new StaffProfilePage() {
                 BindingContext = ((BindableObject)sender).BindingContext
             });
         });

--- a/BITS-App/Pages/StaffPage.xaml.cs
+++ b/BITS-App/Pages/StaffPage.xaml.cs
@@ -1,0 +1,24 @@
+using BITS_App.ViewModels;
+using System.Runtime.CompilerServices;
+
+namespace BITS_App.Pages;
+
+public partial class StaffPage : ContentPage
+{
+	public StaffPage()
+	{
+		InitializeComponent();
+        BindingContext = new StaffViewModel();
+        Dispatcher.Dispatch(async () => await ((StaffViewModel)BindingContext).RefreshAsync());
+    }
+
+    void OnTapGestureRecognizerTapped(object sender, TappedEventArgs e)
+    {
+        Dispatcher.Dispatch(async () => {
+            await Navigation.PushAsync(new StaffProfilePage()
+            {
+                BindingContext = ((BindableObject)sender).BindingContext
+            });
+        });
+    }
+}

--- a/BITS-App/ViewModels/StaffViewModel.cs
+++ b/BITS-App/ViewModels/StaffViewModel.cs
@@ -7,13 +7,13 @@ using System.Runtime.CompilerServices;
 
 namespace BITS_App.ViewModels;
 
-public class PostsViewModel : INotifyPropertyChanged {
-	public ObservableCollection<Post> Posts { get; private set; }
+public class StaffViewModel : INotifyPropertyChanged {
+	public ObservableCollection<StaffProfile> StaffProfiles { get; private set; }
 
     public async Task RefreshAsync() {
         // gets URI for server counterpart to model
-        Uri uri = new($"https://{App.BASE_URL}/wp-json/wp/v2/posts");
-        List<Post> postList = new List<Post>();
+        Uri uri = new($"https://{App.BASE_URL}/wp-json/wp/v2/staff_profile");
+        List<StaffProfile> staffProfileList = new List<StaffProfile>();
 
         // attempts to make an HTTP GET request and deserialize it for easy access
         try {
@@ -21,12 +21,12 @@ public class PostsViewModel : INotifyPropertyChanged {
 
             if (response.IsSuccessStatusCode) {
                 string content = await response.Content.ReadAsStringAsync();
-                List<Json.Post> postJsonList = JsonConvert.DeserializeObject<List<Json.Post>>(content);
-                postList = new List<Post>();
+                List<Json.StaffProfile> staffProfileJsonList = JsonConvert.DeserializeObject<List<Json.StaffProfile>>(content);
+                staffProfileList = new List<StaffProfile>();
 
-                foreach (Json.Post postJson in postJsonList) {
-                    postList.Add(new Post() {
-                        json = postJson
+                foreach (Json.StaffProfile staffProfileJson in staffProfileJsonList) {
+                    staffProfileList.Add(new StaffProfile() {
+                        json = staffProfileJson
                     });
                 }
             }
@@ -34,11 +34,11 @@ public class PostsViewModel : INotifyPropertyChanged {
             Debug.WriteLine(@"\tERROR {0}", ex.Message);
         }
 
-        Posts = new ObservableCollection<Post>(postList);
-        OnPropertyChanged(nameof(Posts));
+        StaffProfiles = new ObservableCollection<StaffProfile>(staffProfileList);
+        OnPropertyChanged(nameof(StaffProfiles));
 
-        foreach (Post post in Posts) {
-            await post.RefreshAsync();
+        foreach (StaffProfile staffProfile in StaffProfiles) {
+            await staffProfile.RefreshAsync();
         }
     }
 

--- a/BITS-App/ViewModels/StaffViewModel.cs
+++ b/BITS-App/ViewModels/StaffViewModel.cs
@@ -18,8 +18,9 @@ public class StaffViewModel : INotifyPropertyChanged {
         // attempts to make an HTTP GET request and deserialize it for easy access
         try {
             HttpResponseMessage response = await App.client.GetAsync(uri);
-
+            Debug.WriteLine("1");
             if (response.IsSuccessStatusCode) {
+                Debug.WriteLine("2");
                 string content = await response.Content.ReadAsStringAsync();
                 List<Json.StaffProfile> staffProfileJsonList = JsonConvert.DeserializeObject<List<Json.StaffProfile>>(content);
                 staffProfileList = new List<StaffProfile>();
@@ -28,7 +29,9 @@ public class StaffViewModel : INotifyPropertyChanged {
                     staffProfileList.Add(new StaffProfile() {
                         json = staffProfileJson
                     });
+                    Debug.WriteLine("loop");
                 }
+                Debug.WriteLine("3");
             }
         } catch (Exception ex) {
             Debug.WriteLine(@"\tERROR {0}", ex.Message);
@@ -40,6 +43,7 @@ public class StaffViewModel : INotifyPropertyChanged {
         foreach (StaffProfile staffProfile in StaffProfiles) {
             await staffProfile.RefreshAsync();
         }
+        int x = 1;
     }
 
     #region INotifyPropertyChanged


### PR DESCRIPTION
This branch contains working backend for the staff page, where multiple staff previews are listed and can be clicked to pull up the StaffProfilePage for each respective staff member.
Notable changes:
- Clicking the "staff" button at the top of the screen now loads up StaffPage (my created page) instead of StaffProfilePage
- There was an error in StaffProfile.cs, Ethan commented it out and left it for someone else to deal with
- Added functionality to the StaffProfile.cs model to store JSON
- Created StaffPage.xaml (scaffolding just to test my changes, Amy will change this)
- Created codebehind for StaffPage.xaml to support bindings for all staff in StaffPage.xaml
- Deleted the public no argument constructor for PostsViewModel (created by default, unnecessary lines)
- Created StaffViewModel that contains a list of StaffProfiles with information about each staff
plz approve